### PR TITLE
Ignore ReflectionExcepition when accesors are "magic" methods.

### DIFF
--- a/ModelDescriber/JMSModelDescriber.php
+++ b/ModelDescriber/JMSModelDescriber.php
@@ -98,11 +98,14 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
                 $reflections[] = new \ReflectionProperty($item->class, $item->name);
             }
 
-            if (null !== $item->getter) {
-                $reflections[] = new \ReflectionMethod($item->class, $item->getter);
-            }
-            if (null !== $item->setter) {
-                $reflections[] = new \ReflectionMethod($item->class, $item->setter);
+            try {
+                if (null !== $item->getter) {
+                    $reflections[] = new \ReflectionMethod($item->class, $item->getter);
+                }
+                if (null !== $item->setter) {
+                    $reflections[] = new \ReflectionMethod($item->class, $item->setter);
+                }
+            } catch (\ReflectionExceptions $ignored) {
             }
 
             $groups = $this->computeGroups($context, $item->type);


### PR DESCRIPTION
Ignore ReflectionException thrown when getter or setter from JMS\ Accessor are "magic" methods.

https://github.com/nelmio/NelmioApiDocBundle/issues/1708